### PR TITLE
add publish on push action

### DIFF
--- a/.github/workflows/push-npm-publish.yml
+++ b/.github/workflows/push-npm-publish.yml
@@ -1,0 +1,15 @@
+on: push
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: npm install
+      - run: npm test
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
"Release" action wasn't Publishing the package, adding this action as well as it should only publish when version number in `package.json` changes, and if both actions fire only one should succeed anyway.