### PR TITLE
Add format option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ export default {
     // and so should be restricted by hostname
     // See: https://www.sanity.io/docs/studio-environment-variables
     apiKey: process.env.SANITY_STUDIO_GOOGLE_TRANSLATE_API_KEY,
+    // (Optional) Format of the translation, either 'html' (default) or 'text'. Text will preserve line breaks in text inputs.
+    format: 'html'
   },
   // 👆 👆 👆
   fieldsets: [

--- a/src/GoogleTranslateInput.tsx
+++ b/src/GoogleTranslateInput.tsx
@@ -66,6 +66,8 @@ const GoogleTranslateInput = React.forwardRef((props, ref) => {
       setIsTranslating(true)
 
       const url = new URL(`https://translation.googleapis.com/language/translate/v2`)
+      const {format} = type?.options ?? {}
+      if (format) url.searchParams.set(`format`, format)
       url.searchParams.set(`key`, apiKey)
       url.searchParams.set(`q`, config.content)
 


### PR DESCRIPTION
I found I needed to set the format of the translation string to preserve line breaks in the text (my clients can't write html!).

So I've added it in as an option inside the configuration - but it could also be done as an option on the text field itself.